### PR TITLE
#4935: return session date in getSubjectDetails and getSessionById

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "moveshelf_api"
-version = "1.6.1"
+version = "1.6.2"
 authors = [
   { name="Moveshelf", email="info@moveshelf.com" },
 ]

--- a/src/moveshelf_api/api.py
+++ b/src/moveshelf_api/api.py
@@ -2006,6 +2006,7 @@ class MoveshelfApi(object):
                         sessions {
                             id
                             projectPath
+                            date
                             clips {
                                 id
                                 title
@@ -2084,7 +2085,7 @@ class MoveshelfApi(object):
 
         Returns:
             dict: A dictionary containing session details, including:
-                  - ID, projectPath, and metadata.
+                  - ID, date, projectPath, and metadata.
                   - Associated project, clips, norms, and patient information.
                   - If include_additional_data is True, also includes additionalData for each clip with download URIs.
         """
@@ -2095,6 +2096,7 @@ class MoveshelfApi(object):
                     ... on Session {
                         id,
                         projectPath,
+                        date,
                         metadata,
                         project {
                             id
@@ -2138,6 +2140,7 @@ class MoveshelfApi(object):
                     ... on Session {
                         id,
                         projectPath,
+                        date,
                         metadata,
                         project {
                             id


### PR DESCRIPTION
Return session date in getSubjectDetails and getSessionById. This is needed for the KB examples to correctly find existing sessions by session date, replacing the previous logic that uses the projectPath